### PR TITLE
let this chain support default port config for defferent network type (mainnet|testnet|dev)

### DIFF
--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -1,4 +1,12 @@
-use sc_cli::RunCmd;
+use std::net::SocketAddr;
+
+use sc_cli::{
+    build_runtime, ChainSpec, CliConfiguration, DefaultConfigurationValues, ImportParams,
+    KeystoreParams, NetworkParams, OffchainWorkerParams, Result, Role, RunCmd, Runner,
+    SharedParams, SubstrateCli,
+};
+use sc_service::{config::PrometheusConfig, BasePath, TransactionPoolOptions};
+use sc_telemetry::TelemetryEndpoints;
 
 #[derive(Debug, clap::Parser)]
 pub struct Cli {
@@ -7,6 +15,136 @@ pub struct Cli {
 
     #[clap(flatten)]
     pub run: RunCmd,
+}
+
+impl DefaultConfigurationValues for Cli {
+    fn p2p_listen_port() -> u16 {
+        9922
+    }
+
+    fn rpc_ws_listen_port() -> u16 {
+        9944
+    }
+
+    fn rpc_http_listen_port() -> u16 {
+        9933
+    }
+
+    fn prometheus_listen_port() -> u16 {
+        9616
+    }
+}
+
+/// A copy implementation for RunCmd, but the generic type `DCV` in `CliConfiguration<DCV>` is `Cli`.
+/// Notice this implementation should be updated if the `CliConfiguration` implementation for `RunCmd`
+/// has changed.
+/// More exactly, the function which should be implemented for `Cli` is the one that be called in
+/// `create_configuration` function, while it's also overridden by `RunCmd`.
+/// Thus, the easiest way is to override all functions which are overridden for `RunCmd`.
+impl CliConfiguration<Self> for Cli {
+    fn shared_params(&self) -> &SharedParams {
+        self.run.shared_params()
+    }
+    fn import_params(&self) -> Option<&ImportParams> {
+        self.run.import_params()
+    }
+    fn network_params(&self) -> Option<&NetworkParams> {
+        self.run.network_params()
+    }
+    fn keystore_params(&self) -> Option<&KeystoreParams> {
+        self.run.keystore_params()
+    }
+    fn offchain_worker_params(&self) -> Option<&OffchainWorkerParams> {
+        self.run.offchain_worker_params()
+    }
+    fn node_name(&self) -> Result<String> {
+        self.run.node_name()
+    }
+    fn dev_key_seed(&self, is_dev: bool) -> Result<Option<String>> {
+        self.run.dev_key_seed(is_dev)
+    }
+    fn telemetry_endpoints(
+        &self,
+        chain_spec: &Box<dyn ChainSpec>,
+    ) -> Result<Option<TelemetryEndpoints>> {
+        self.run.telemetry_endpoints(chain_spec)
+    }
+    fn role(&self, is_dev: bool) -> Result<Role> {
+        self.run.role(is_dev)
+    }
+    fn force_authoring(&self) -> Result<bool> {
+        self.run.force_authoring()
+    }
+    fn prometheus_config(
+        &self,
+        default_listen_port: u16,
+        chain_spec: &Box<dyn ChainSpec>,
+    ) -> Result<Option<PrometheusConfig>> {
+        self.run.prometheus_config(default_listen_port, chain_spec)
+    }
+    fn disable_grandpa(&self) -> Result<bool> {
+        self.run.disable_grandpa()
+    }
+    fn rpc_ws_max_connections(&self) -> Result<Option<usize>> {
+        self.run.rpc_ws_max_connections()
+    }
+
+    fn rpc_cors(&self, is_dev: bool) -> Result<Option<Vec<String>>> {
+        self.run.rpc_cors(is_dev)
+    }
+    fn rpc_http(&self, default_listen_port: u16) -> Result<Option<SocketAddr>> {
+        self.run.rpc_http(default_listen_port)
+    }
+    fn rpc_ipc(&self) -> Result<Option<String>> {
+        self.run.rpc_ipc()
+    }
+    fn rpc_ws(&self, default_listen_port: u16) -> Result<Option<SocketAddr>> {
+        self.run.rpc_ws(default_listen_port)
+    }
+    fn rpc_methods(&self) -> Result<sc_service::config::RpcMethods> {
+        self.run.rpc_methods()
+    }
+    fn rpc_max_payload(&self) -> Result<Option<usize>> {
+        self.run.rpc_max_payload()
+    }
+
+    fn ws_max_out_buffer_capacity(&self) -> Result<Option<usize>> {
+        self.run.ws_max_out_buffer_capacity()
+    }
+    fn transaction_pool(&self) -> Result<TransactionPoolOptions> {
+        self.run.transaction_pool()
+    }
+    fn max_runtime_instances(&self) -> Result<Option<usize>> {
+        self.run.max_runtime_instances()
+    }
+    fn runtime_cache_size(&self) -> Result<u8> {
+        self.run.runtime_cache_size()
+    }
+    fn base_path(&self) -> Result<Option<BasePath>> {
+        self.run.base_path()
+    }
+}
+
+impl Cli {
+    /// Build a runner based on `RunCmd`.
+    /// This function is same as `create_runner` in `SubstrateCli`, but it just uses for `RunCmd`.
+    pub fn create_runner_for_run_cmd(&self, command: &RunCmd) -> Result<Runner<Self>> {
+        let tokio_runtime = build_runtime()?;
+        // we use our custom configuration (`Self`) to replace `RunCmd`'s configuration.
+        let config = CliConfiguration::<Self>::create_configuration(
+            self,
+            self,
+            tokio_runtime.handle().clone(),
+        )?;
+
+        command.init(
+            &Self::support_url(),
+            &Self::impl_version(),
+            |_, _| {},
+            &config,
+        )?;
+        Runner::new(config, tokio_runtime)
+    }
 }
 
 #[derive(Debug, clap::Subcommand)]

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -189,7 +189,7 @@ pub fn run() -> sc_cli::Result<()> {
 				You can enable it with `--features try-runtime`."
             .into()),
         None => {
-            let runner = cli.create_runner(&cli.run)?;
+            let runner = cli.create_runner_for_run_cmd(&cli.run)?;
             runner.run_node_until_exit(|config| async move {
                 service::new_full(config).map_err(sc_cli::Error::Service)
             })


### PR DESCRIPTION
1. though substrate provides a way to config the port, but it has some limitation:
    1. the `DefaultConfigurationValues` is used in `CliConfiguration`, and `CliConfiguration` just implements for all `*Cmd`. Thus we just can use a custom `CliConfiguration` to replace the implementation for `RunCmd`.
    2. the `DefaultConfigurationValues` does not have `&self`, so it can just peek the information from a const value or a static value. it must bring in `unsafe` which the information should be changed during starting.
2. we do not wanna modify the implementation of `create_configuration`, so if we need the `chain_spec.id()`, we just can re-run the `load_spec` to generate an useless `ChainSpec`, get the `id` and drop it. Luckily, this process just casts less resource. However it's not a genteel way.